### PR TITLE
Use the URI specified in the API explorer UI.

### DIFF
--- a/pythoncivicrm/pythoncivicrm.py
+++ b/pythoncivicrm/pythoncivicrm.py
@@ -94,7 +94,7 @@ class CiviCRM:
             start = 'https://'
         else:
             start = 'http://'
-        self.url =  "%s%s/extern/rest.php" % (start, self.urlstring)
+        self.url =  "%s%s/civicrm/ajax/rest" % (start, self.urlstring)
 
     def _get(self, action, entity, parameters=None):
         """Internal method to make api calls"""
@@ -140,7 +140,7 @@ class CiviCRM:
                 }
         # these should all be set explicitly so remove from parameters
         for badparam in ['site_key', 'api_key', 'entity', 'action', 
-                'json']:
+                         'json']:
             parameters.pop(badparam, None)
         # add in parameters
         payload.update(parameters)


### PR DESCRIPTION
This request changes the URI added to the provided URL to that shown in the API Explorer. I guess 'extern/rest.php' is in some sense equivalent, but I'm not sure in what way, and for me at least this change is necessary to make things work.

If the change is not needed, I would love to understand why.
