### PR TITLE
Permit json-encoded parameters on POST requests.

### DIFF
--- a/pythoncivicrm/pythoncivicrm.py
+++ b/pythoncivicrm/pythoncivicrm.py
@@ -257,7 +257,7 @@ class CiviCRM:
             in the request.
         """
         payload = self._payload_template(action, entity)
-        notparams = ['site_key', 'api_key', 'entity', 'action', 'json']
+        notparams = ['site_key', 'api_key', 'entity', 'action']
         return self._filter_merge_payload(parameters, payload, notparams)
 
     def _add_options(self, params, **kwargs):


### PR DESCRIPTION
Enables Mailing create with groups = array(). Provides a simple but non-optimal solution to:

https://github.com/tallus/python-civicrm/issues/16

See also:

http://forum.civicrm.org/index.php/topic,35567.msg151610.html#msg151610